### PR TITLE
Updated references to project-avral products after rebranding.

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,8 +107,10 @@
           by <a href="https://github.com/icarus-consulting">@icarus-consulting</a> (C# port of Cactoos)</li>
         <li><a href="https://github.com/neonailol/kactoos">Kactoos</a>
           by <a href="https://github.com/neonailol">@neonailol</a> (Kotlin port of Cactoos)</li>
-        <li><a href="https://github.com/project-avral/oo-atom">OO-Atom</a>
-          by <a href="https://github.com/project-avral">@project-avral</a> (Java)</li>
+        <li><a href="https://github.com/pragmatic-objects/oo-atom">OO-Atom</a>
+          by <a href="https://github.com/pragmatic-objects">@pragmatic-objects</a> (Java)</li>
+        <li><a href="https://github.com/pragmatic-objects/oo-tests">OO-Tests</a>
+          by <a href="https://github.com/pragmatic-objects">@pragmatic-objects</a> (Java)</li>
         <li><a href="https://github.com/Vatavuk/vgv-xls">Vgv-xls</a>
           by <a href="https://github.com/Vatavuk">@Vatavuk</a> (Java)</li>
         <li><a href="https://github.com/g4s8/cactoos-crypto">cactoos-crypto

--- a/index.html
+++ b/index.html
@@ -111,8 +111,6 @@
           by <a href="https://github.com/pragmatic-objects">@pragmatic-objects</a> (Java)</li>
         <li><a href="https://github.com/pragmatic-objects/oo-tests">OO-Tests</a>
           by <a href="https://github.com/pragmatic-objects">@pragmatic-objects</a> (Java)</li>
-        <li><a href="https://github.com/Vatavuk/vgv-xls">Vgv-xls</a>
-          by <a href="https://github.com/Vatavuk">@Vatavuk</a> (Java)</li>
         <li><a href="https://github.com/Vatavuk/excel-io">excel-io</a>
           by <a href="https://github.com/Vatavuk">@Vatavuk</a> (Java)</li>        
         <li><a href="https://github.com/g4s8/cactoos-crypto">cactoos-crypto

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
         <li><a href="https://github.com/pragmatic-objects/oo-tests">OO-Tests</a>
           by <a href="https://github.com/pragmatic-objects">@pragmatic-objects</a> (Java)</li>
         <li><a href="https://github.com/Vatavuk/excel-io">excel-io</a>
-          by <a href="https://github.com/Vatavuk">@Vatavuk</a> (Java)</li>        
+          by <a href="https://github.com/Vatavuk">@Vatavuk</a> (Java)</li>
         <li><a href="https://github.com/g4s8/cactoos-crypto">cactoos-crypto
           by <a href="https://github.com/g4s8">@g4s8</a> (Java)</a></li>
         <li><a href="https://github.com/llorllale/cactoos-matchers">cactoos-matchers</a>


### PR DESCRIPTION
Recently I did a big reorganization inside @project-avral and its projects. Now it is named @pragmatic-objects.

- Changed the name of my GitHub organization from project-avral to pragmatic-objects.
- Also, OO-Atom was splat to two products - OO-Atom and OO-Tests. Reflected that too.