### PR TITLE
Removed irrelevant badges for IntelliJ and RubyMine

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,8 +208,6 @@
         Badges for your GitHub repo:
         <p>
         <img src="//www.elegantobjects.org/badge.svg" alt="EO badge"/>
-        <img src="//www.elegantobjects.org/intellij-idea.svg" alt="IntelliJ IDEA badge"/>
-        <img src="//www.elegantobjects.org/rubymine.svg" alt="RubyMine badge"/>
       </p>
       <p>
         If you want to join our core team, text <a href="https://t.me/yegor256">@yegor256</a> in Telegram.


### PR DESCRIPTION
I do not understand what IntelliJ or RubyMine (or any IDE for that matter) has anything to do with the principles of Elegant Objects, so I propose we remove them.