### PR TITLE
pragmatic stack updated

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,9 +107,13 @@
           by <a href="https://github.com/icarus-consulting">@icarus-consulting</a> (C# port of Cactoos)</li>
         <li><a href="https://github.com/neonailol/kactoos">Kactoos</a>
           by <a href="https://github.com/neonailol">@neonailol</a> (Kotlin port of Cactoos)</li>
-        <li><a href="https://github.com/pragmatic-objects/oo-atom">OO-Atom</a>
+        <li><a href="https://github.com/pragmatic-objects/oo-equivalence">OO-Equivalence</a>
           by <a href="https://github.com/pragmatic-objects">@pragmatic-objects</a> (Java)</li>
         <li><a href="https://github.com/pragmatic-objects/oo-tests">OO-Tests</a>
+          by <a href="https://github.com/pragmatic-objects">@pragmatic-objects</a> (Java)</li>
+        <li><a href="https://github.com/pragmatic-objects/oo-memoized">OO-Memoized</a>
+          by <a href="https://github.com/pragmatic-objects">@pragmatic-objects</a> (Java)</li>
+        <li><a href="https://github.com/pragmatic-objects/oo-inference">OO-Inference</a>
           by <a href="https://github.com/pragmatic-objects">@pragmatic-objects</a> (Java)</li>
         <li><a href="https://github.com/Vatavuk/excel-io">excel-io</a>
           by <a href="https://github.com/Vatavuk">@Vatavuk</a> (Java)</li>


### PR DESCRIPTION
OO-Atom was deprecated in favor of OO-Equivalence
Added OO-Memoized and OO-Inference