### PR TITLE
Add BriX for building data structures

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,6 +172,8 @@
           by <a href="https://github.com/Vatavuk">@Vatavuk</a> (Java)</li>
 	<li><a href="https://github.com/icarus-consulting/Yaapii.Http">yaapii.http</a>
           by <a href="https://github.com/icarus-consulting">C# port of verano-http</a> (C#)</li>
+	<li><a href="https://github.com/icarus-consulting/BriX">BriX</a>
+          by <a href="https://github.com/icarus-consulting">OOP printable data structures</a> (C#)</li>	      
         <li><a href="https://github.com/icarus-consulting/Xive">Xive</a>
           by <a href="https://github.com/icarus-consulting">@icarus-consulting</a> (C#)</li>
 	      <li><a href="https://github.com/proshin-roman/finapi-java-client">finapi-java-client</a>


### PR DESCRIPTION
We developed a small library which you can use to build data objects.
These objects can be printed to media, following the printer pattern. The objects available in the library are a format-feature-merge of XML and JSON so when you use the library, you ensure that these media types are supported.