### PR TITLE
Add cjson

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,8 @@
           by <a href="https://github.com/l3r8yJ">@l3r8yJ</a> (Java)</li>
         <li><a href="https://eo-cqrs.github.io/eo-kafka/">eo-kafka</a>
           by <a href="https://github.com/eo-cqrs">@EO-CQRS</a> (Java)</li>
+	<li><a href="https://github.com/kerelape/cjson">cjson</a> 
+          by <a href="https://github.com/kerelape">@kerelape</a> (Go)</li>
       </ul>
       <p>
         Products:


### PR DESCRIPTION
[cjson](https://github.com/kerelape/cjson) is an object-oriented JSON library for Go. It only violates some EO principles like type-casting and _static_ methods when it's required for compatibility with the standard `encoding/json` package.