### PR TITLE
Add ZiZZi, a library for elegant data objects to replace DTO 

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,6 +181,8 @@
           by <a href="https://github.com/Vatavuk">@Vatavuk</a> (Java)</li>
 	<li><a href="https://github.com/icarus-consulting/Yaapii.Http">yaapii.http</a>
           by <a href="https://github.com/icarus-consulting">C# port of verano-http</a> (C#)</li>
+	<li><a href="https://github.com/Meerownymous/ZiZZi">ZiZZi</a> Declarative object oriented data printers
+          by <a href="https://github.com/Meerownymous">Meerownymous</a> (C#)</li>	      
 	<li><a href="https://github.com/icarus-consulting/BriX">BriX</a>
           by <a href="https://github.com/icarus-consulting">OOP printable data structures</a> (C#)</li>
         <li><a href="https://github.com/icarus-consulting/Xive">Xive</a>


### PR DESCRIPTION
ZiZZi is a library which allows to declare data without deciding about the final format. Data can then be printed as xml, json or property objects for frameworks in which DTO based binding cannot be avoided (usually UI).