### PR TITLE
Add flake8-elegant-objects to the list

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,8 @@
           by <a href="https://github.com/orgs/elegant-bro/projects">elegant-bro</a> (PHP, Golang)</li>
         <li><a href="https://github.com/roch1990/peon">peon</a>
           by <a href="https://github.com/roch1990">@roch1990</a> (Python3)</li>
+        <li><a href="https://github.com/AntonProkopyev/flake8-elegant-objects">flake8-elegant-objects</a>
+          by <a href="https://github.com/AntonProkopyev">@AntonProkopyev</a> (Python)</li>
         <li><a href="https://github.com/maxonfjvipon/ElegantElephant">ElegantElephant</a>
           by <a href="https://github.com/maxonfjvipon">@maxonfjvipon</a> (PHP)</li>
 	<li><a href="https://github.com/kerelape/reikai">Reikai</a>


### PR DESCRIPTION
A flake8 plugin that checks Python against the principles on this page: no null, no code in constructors, no getters and setters, no mutable objects, no -er names, no static methods, no type discrimination, no public methods without a contract, no statements in tests beyond the assertion, no ORM, no implementation inheritance.

Every message it prints ends with a link to the article behind the rule, taken from this page.

It is on PyPI as [flake8-elegant-objects](https://pypi.org/project/flake8-elegant-objects/) and runs either through flake8 (`flake8 --select=EO`) or on its own.

Placed next to peon, the other Python entry in the list.