### PR TITLE
Add @lymagics to the list of fans

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,6 +278,7 @@
         <a href="https://github.com/kudima03">@kudima03</a>,
         <a href="https://github.com/Karpikova">@Karpikova</a>,
         <a href="https://github.com/l3r8yJ/">@l3r8yJ</a>,
+        <a href="https://github.com/lymagics">@lymagics</a>,
         <a href="https://github.com/Maratori">@maratori</a>,
         <a href="https://github.com/marijnz0r">@marijnz0r</a>,
         <a href="https://github.com/maxonfjvipon">@maxonfjvipon</a>,


### PR DESCRIPTION
This PR adds @lymagics to the "Fans" section on the Elegant Objects homepage.

## Changes
- Added a link to the @lymagics GitHub profile in `index.html`, keeping the list in alphabetical order.